### PR TITLE
Remove fist program argument from multichecker

### DIFF
--- a/multichecker/checker.go
+++ b/multichecker/checker.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/gqlgo/gqlanalysis"
 	"github.com/gqlgo/gqlanalysis/internal/checker"
@@ -16,16 +15,15 @@ var (
 )
 
 func init() {
-	flag.StringVar(&flagSchema, "schema", "schema", "pattern of schema")
-	flag.StringVar(&flagQuery, "query", "query", "pattern of query")
+	flag.StringVar(&flagSchema, "schema", "schema/**/*.graphql", "pattern of schema")
+	flag.StringVar(&flagQuery, "query", "query/**/*.graphql", "pattern of query")
 }
 
 func Main(analyzers ...*gqlanalysis.Analyzer) {
 	flag.Parse()
-	dir := flag.Arg(0)
 	checker := &checker.Checker{
-		Schema: filepath.Join(dir, flagSchema),
-		Query:  filepath.Join(dir, flagQuery),
+		Schema: flagSchema,
+		Query:  flagQuery,
 	}
 	if err := checker.Run(analyzers...); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)


### PR DESCRIPTION
First program argument is no longer needed because gqlanalysis uses zglob.