### PR TITLE
Add CLI argument for introspection-header

### DIFF
--- a/multichecker/checker.go
+++ b/multichecker/checker.go
@@ -19,7 +19,7 @@ var ih = make(introspectionHeader)
 func init() {
 	flag.StringVar(&flagSchema, "schema", "schema/**/*.graphql", "pattern of schema")
 	flag.StringVar(&flagQuery, "query", "query/**/*.graphql", "pattern of query")
-	flag.Var(ih, "introspectionHeader", "format key1=value1,key2=value2")
+	flag.Var(ih, "introspection-header", "format key1=value1,key2=value2")
 }
 
 func Main(analyzers ...*gqlanalysis.Analyzer) {

--- a/multichecker/checker.go
+++ b/multichecker/checker.go
@@ -2,6 +2,7 @@ package multichecker
 
 import (
 	"flag"
+	"net/http"
 	"os"
 
 	"github.com/gqlgo/gqlanalysis"
@@ -13,16 +14,20 @@ var (
 	flagQuery  string
 )
 
+var ih = make(introspectionHeader)
+
 func init() {
 	flag.StringVar(&flagSchema, "schema", "schema/**/*.graphql", "pattern of schema")
 	flag.StringVar(&flagQuery, "query", "query/**/*.graphql", "pattern of query")
+	flag.Var(ih, "introspectionHeader", "format key1=value1,key2=value2")
 }
 
 func Main(analyzers ...*gqlanalysis.Analyzer) {
 	flag.Parse()
 	checker := &checker.Checker{
-		Schema: flagSchema,
-		Query:  flagQuery,
+		Schema:              flagSchema,
+		Query:               flagQuery,
+		IntrospectionHeader: http.Header(ih),
 	}
 
 	os.Exit(checker.Run(analyzers...))

--- a/multichecker/checker.go
+++ b/multichecker/checker.go
@@ -19,7 +19,7 @@ var ih = make(introspectionHeader)
 func init() {
 	flag.StringVar(&flagSchema, "schema", "schema/**/*.graphql", "pattern of schema")
 	flag.StringVar(&flagQuery, "query", "query/**/*.graphql", "pattern of query")
-	flag.Var(ih, "introspection-header", "format \"key1:value1,key2:value2\"")
+	flag.Var(ih, "introspection-header", "format key1:value1,key2:value2")
 }
 
 func Main(analyzers ...*gqlanalysis.Analyzer) {

--- a/multichecker/checker.go
+++ b/multichecker/checker.go
@@ -19,7 +19,7 @@ var ih = make(introspectionHeader)
 func init() {
 	flag.StringVar(&flagSchema, "schema", "schema/**/*.graphql", "pattern of schema")
 	flag.StringVar(&flagQuery, "query", "query/**/*.graphql", "pattern of query")
-	flag.Var(ih, "introspection-header", "format key1=value1,key2=value2")
+	flag.Var(ih, "introspection-header", "format \"key1:value1,key2:value2\"")
 }
 
 func Main(analyzers ...*gqlanalysis.Analyzer) {

--- a/multichecker/export_test.go
+++ b/multichecker/export_test.go
@@ -1,0 +1,3 @@
+package multichecker
+
+type ExportedIntrospectionHeader = introspectionHeader

--- a/multichecker/introspection_header.go
+++ b/multichecker/introspection_header.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// introspectionHeader is conformance to `Value` in flag package.
+// introspectionHeader confirmed to `Value` interface in `flag` package.
 type introspectionHeader http.Header
 
 func (ih introspectionHeader) String() string {

--- a/multichecker/introspection_header.go
+++ b/multichecker/introspection_header.go
@@ -26,8 +26,9 @@ func (ih introspectionHeader) Set(args string) error {
 		keyAndValue := strings.Split(keyAndValueString, ":")
 		key := keyAndValue[0]
 		value := keyAndValue[1]
+
 		// Supports only one value.
-		ih[key][0] = value
+		ih[key] = []string{value}
 	}
 	return nil
 

--- a/multichecker/introspection_header.go
+++ b/multichecker/introspection_header.go
@@ -15,7 +15,7 @@ func (ih introspectionHeader) String() string {
 		if len(s) != 0 {
 			s += ","
 		}
-		s += fmt.Sprintf("%v=%v", k, v)
+		s += fmt.Sprintf("%v:%v", k, v)
 	}
 	return s
 }
@@ -23,7 +23,7 @@ func (ih introspectionHeader) String() string {
 func (ih introspectionHeader) Set(args string) error {
 	keyAndValueList := strings.Split(args, ",")
 	for _, keyAndValueString := range keyAndValueList {
-		keyAndValue := strings.Split(keyAndValueString, "=")
+		keyAndValue := strings.Split(keyAndValueString, ":")
 		key := keyAndValue[0]
 		value := keyAndValue[1]
 		// Supports only one value.

--- a/multichecker/introspection_header.go
+++ b/multichecker/introspection_header.go
@@ -15,14 +15,13 @@ func (ih introspectionHeader) String() string {
 		if len(s) != 0 {
 			s += ","
 		}
-		s += fmt.Sprintf("%v:%v", k, v)
+		s += fmt.Sprintf("%v:%v", k, v[0])
 	}
 	return s
 }
 
 func (ih introspectionHeader) Set(args string) error {
-	keyAndValueList := strings.Split(args, ",")
-	for _, keyAndValueString := range keyAndValueList {
+	for _, keyAndValueString := range strings.Split(args, ",") {
 		keyAndValue := strings.Split(keyAndValueString, ":")
 		key := keyAndValue[0]
 		value := keyAndValue[1]

--- a/multichecker/introspection_header.go
+++ b/multichecker/introspection_header.go
@@ -1,0 +1,34 @@
+package multichecker
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// introspectionHeader is conformance to `Value` in flag package.
+type introspectionHeader http.Header
+
+func (ih introspectionHeader) String() string {
+	var s string
+	for k, v := range ih {
+		if len(s) != 0 {
+			s += ","
+		}
+		s += fmt.Sprintf("%v=%v", k, v)
+	}
+	return s
+}
+
+func (ih introspectionHeader) Set(args string) error {
+	keyAndValueList := strings.Split(args, ",")
+	for _, keyAndValueString := range keyAndValueList {
+		keyAndValue := strings.Split(keyAndValueString, "=")
+		key := keyAndValue[0]
+		value := keyAndValue[1]
+		// Supports only one value.
+		ih[key][0] = value
+	}
+	return nil
+
+}

--- a/multichecker/introspection_header_test.go
+++ b/multichecker/introspection_header_test.go
@@ -1,0 +1,54 @@
+package multichecker_test
+
+import (
+	"testing"
+
+	"github.com/gqlgo/gqlanalysis/multichecker"
+)
+
+func TestIntrospectionHeader_Set(t *testing.T) {
+	cases := []struct {
+		args string
+		want map[string]string
+	}{
+		{"key1:value1", map[string]string{"key1": "value1"}},
+		{"key1:value1,key2:value2", map[string]string{"key1": "value1", "key2": "value2"}},
+	}
+
+	for _, tt := range cases {
+		actual := make(multichecker.ExportedIntrospectionHeader)
+		actual.Set(tt.args)
+
+		if len(actual) != len(tt.want) {
+			t.Errorf("len(actual) != len(tt.want). actual: %v, want: %v", actual, tt.want)
+		}
+		for wantKey, wantValue := range tt.want {
+			actualValue, ok := actual[wantKey]
+			if !ok {
+				t.Errorf("Does not contain key: %s", wantKey)
+			}
+			if wantValue != actualValue[0] {
+				t.Errorf("wantValue is not equal actualValue. key: %v, wantKey: %v, actualValue: %v", wantKey, wantValue, actualValue)
+			}
+		}
+	}
+}
+
+func TestIntrospectionHeader_Value(t *testing.T) {
+	cases := []struct {
+		want string
+	}{
+		{"key1:value1"},
+		{"key1:value1,key2:value2"},
+	}
+
+	for _, tt := range cases {
+		ih := make(multichecker.ExportedIntrospectionHeader)
+		ih.Set(tt.want)
+		actual := ih.String(
+)
+		if actual != tt.want {
+			t.Errorf("actual != tt.want. actual: %v, want: %v", actual, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Abstract
認証を介さないと取得できないGraphQLスキーマが存在している。内部ではintrospection時にHTTP Headerを付与できるコードになっていたのでコマンドラインから引数で受け取れるようにする

コマンドライン引数の形式は `-introspeciton-header=key1:value1,key2:value2`。最終的にはhttp.Header(=map[string][]string)として扱うが、introspectionでhttpを配列に渡したいことが思いつかないのでkey:valueは1:1にしてしまっている。理由は1:1じゃない場合のmapを引数で受け取る場合の適切なフォーマットが思い浮かばなかったのが大きな要因。PRに書いてあるような具合ならわかりやすいと思っている

## How
flag パッケージの `Value` インタフェースに準拠すればデフォルト以外の型も扱えるのでその方式をとっている。"key1:value1"が引数れあれば実態は `map[string][]string{ "key1": []string{"value1"} }` になる